### PR TITLE
feat: add HTTP proxy support with CONNECT method handling

### DIFF
--- a/nx.go
+++ b/nx.go
@@ -318,7 +318,16 @@ func handleShellListener(listener net.Listener, connStr string) {
 
 			// set env var back home for convenience
 			time.Sleep(opts.Sleep)
-			_ = execInWindow(window, fmt.Sprintf(" export ME=%s", connStr))
+			_ = execInWindow(
+				window,
+				fmt.Sprintf(
+					" export ME=%s all_proxy=http://%s http_proxy=http://%s https_proxy=http://%s",
+					connStr,
+					connStr,
+					connStr,
+					connStr,
+				),
+			)
 
 			// Handle plugin execution
 			if opts.Auto {


### PR DESCRIPTION
  - Add combined HTTP server to handle both file serving and proxy requests
  - Implement HTTPS proxy support via CONNECT method with connection hijacking
  - Add HTTP proxy functionality with proper header filtering
  - Restructure protocol matching to prioritize SSH, then CONNECT, then HTTP
  - Reduce connection multiplexer read timeout from 2s to 1s
  - Support proxy detection via absolute URLs and proxy headers
