### PR TITLE
feat(pty): replace socat with internal PTY manager and session bridge

### DIFF
--- a/internal/bridge/manager.go
+++ b/internal/bridge/manager.go
@@ -1,0 +1,103 @@
+// Package pty provides a PTY (pseudo-terminal) connection management system
+// that replaces the previous socat dependency. It enables bidirectional
+// communication between stdin/stdout and Unix domain sockets through
+// managed sessions with proper resource cleanup and error handling.
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+)
+
+
+
+// Session represents an active stdio-to-socket bridge session
+type Session struct {
+	socketConn net.Conn
+	ctx        context.Context
+	cancel     context.CancelFunc
+	errChan    chan error
+	closeOnce  sync.Once
+}
+
+
+
+// NewSession creates a new PTY session connected to the specified Unix socket
+func NewSession(socketPath string) (*Session, error) {
+	socketConn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to socket %s: %w", socketPath, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	session := &Session{
+		socketConn: socketConn,
+		ctx:        ctx,
+		cancel:     cancel,
+		errChan:    make(chan error, 2),
+	}
+
+	return session, nil
+}
+
+
+
+// Start begins the bidirectional communication between stdin/stdout and the socket.
+func (s *Session) Start() error {
+	go s.copyStdinToSocket()
+	go s.copySocketToStdout()
+
+	select {
+	case err := <-s.errChan:
+		return err
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
+}
+
+// Close cleans up all resources associated with the session
+func (s *Session) Close() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	var closeErr error
+	s.closeOnce.Do(func() {
+		if s.socketConn != nil {
+			closeErr = s.socketConn.Close()
+		}
+	})
+
+	return closeErr
+}
+
+// copyStdinToSocket copies data from stdin to the socket connection.
+// This enables input from the local terminal to be sent to the remote PTY.
+func (s *Session) copyStdinToSocket() {
+	defer s.closeOnce.Do(func() {
+		if s.socketConn != nil {
+			s.socketConn.Close()
+		}
+	})
+	_, err := io.Copy(s.socketConn, os.Stdin)
+	s.errChan <- err
+}
+
+// copySocketToStdout copies data from the socket connection to stdout.
+// This enables output from the remote PTY to be displayed on the local terminal.
+func (s *Session) copySocketToStdout() {
+	defer s.closeOnce.Do(func() {
+		if s.socketConn != nil {
+			s.socketConn.Close()
+		}
+	})
+	_, err := io.Copy(os.Stdout, s.socketConn)
+	s.errChan <- err
+}
+
+

--- a/internal/bridge/manager_test.go
+++ b/internal/bridge/manager_test.go
@@ -1,0 +1,372 @@
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+
+
+func TestCreateSession(t *testing.T) {
+	// Create temporary socket
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	// Create Unix socket listener
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Failed to create socket listener: %v", err)
+	}
+	defer listener.Close()
+
+	// Accept connections in background
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Just close the connection for this test
+			conn.Close()
+		}
+	}()
+
+	// Create session
+	session, err := NewSession(socketPath)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	defer session.Close()
+
+	// Verify session was created
+	if session.socketConn == nil {
+		t.Fatal("Socket connection not established")
+	}
+}
+
+func TestNewSession(t *testing.T) {
+	// Create temporary socket
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	// Create Unix socket listener
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Failed to create socket listener: %v", err)
+	}
+	defer listener.Close()
+
+	// Accept connections in background
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Just close the connection for this test
+			conn.Close()
+		}
+	}()
+
+	// Create session using new API
+	session, err := NewSession(socketPath)
+	if err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+	defer session.Close()
+
+	// Verify session was created
+	if session.socketConn == nil {
+		t.Fatal("Socket connection not established")
+	}
+	if session.ctx == nil {
+		t.Fatal("Context not initialized")
+	}
+	if session.cancel == nil {
+		t.Fatal("Cancel function not initialized")
+	}
+	if session.errChan == nil {
+		t.Fatal("Error channel not initialized")
+	}
+}
+
+func TestSessionClose(t *testing.T) {
+	// Create temporary socket
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	// Create Unix socket listener
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Failed to create socket listener: %v", err)
+	}
+	defer listener.Close()
+
+	// Accept one connection
+	go func() {
+		conn, _ := listener.Accept()
+		if conn != nil {
+			// Keep connection open briefly
+			time.Sleep(100 * time.Millisecond)
+			conn.Close()
+		}
+	}()
+
+	// Create and close session
+	session, err := NewSession(socketPath)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	// Close should not error
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	// Second close should not panic
+	session.Close()
+}
+
+
+
+func TestSessionLifecycle(t *testing.T) {
+	// Create temporary socket
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	// Create Unix socket listener
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Failed to create socket listener: %v", err)
+	}
+	defer listener.Close()
+
+	// Accept connections and close them immediately
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Close immediately to trigger session completion
+			conn.Close()
+		}
+	}()
+
+	// Create session
+	session, err := NewSession(socketPath)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	defer session.Close()
+
+	// Start session in goroutine (it should complete quickly due to closed connection)
+	done := make(chan error, 1)
+	go func() {
+		done <- session.Start()
+	}()
+
+	// Wait for completion with timeout
+	select {
+	case err := <-done:
+		// Session should complete (possibly with error due to closed connection)
+		t.Logf("Session completed with: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Session did not complete within timeout")
+	}
+}
+
+func TestConcurrentSessions(t *testing.T) {
+	// Create temporary directory for sockets
+	tmpDir := t.TempDir()
+
+	// Create multiple socket listeners
+	const numSessions = 5
+	listeners := make([]net.Listener, numSessions)
+	socketPaths := make([]string, numSessions)
+
+	for i := range numSessions {
+		socketPaths[i] = filepath.Join(tmpDir, fmt.Sprintf("test%d.sock", i))
+		listener, err := net.Listen("unix", socketPaths[i])
+		if err != nil {
+			t.Fatalf("Failed to create socket listener %d: %v", i, err)
+		}
+		listeners[i] = listener
+		defer listener.Close()
+
+		// Accept and immediately close connections
+		go func(l net.Listener) {
+			for {
+				conn, err := l.Accept()
+				if err != nil {
+					return
+				}
+				conn.Close()
+			}
+		}(listener)
+	}
+
+	// Create sessions concurrently
+	var wg sync.WaitGroup
+	errors := make(chan error, numSessions)
+
+	for i := range numSessions {
+		wg.Add(1)
+		go func(socketPath string) {
+			defer wg.Done()
+
+			session, err := NewSession(socketPath)
+			if err != nil {
+				errors <- fmt.Errorf("CreateSession failed: %w", err)
+				return
+			}
+			defer session.Close()
+
+			// Start session (should complete quickly)
+			err = session.Start()
+			if err != nil {
+				t.Logf("Session completed with expected error: %v", err)
+			}
+		}(socketPaths[i])
+	}
+
+	// Wait for all sessions to complete
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case err := <-errors:
+		t.Fatalf("Concurrent session error: %v", err)
+	case <-done:
+		t.Log("All concurrent sessions completed successfully")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Concurrent sessions did not complete within timeout")
+	}
+}
+
+func TestErrorHandlingScenarios(t *testing.T) {
+	// Test 1: Invalid socket path
+	_, err := NewSession("/nonexistent/path/test.sock")
+	if err == nil {
+		t.Error("Expected error for invalid socket path, got nil")
+	}
+
+	// Test 2: Session with nil connection (edge case)
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	// Create socket but don't listen
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Failed to create socket: %v", err)
+	}
+	listener.Close() // Close immediately
+
+	// Try to create session with closed socket
+	_, err = NewSession(socketPath)
+	if err == nil {
+		t.Error("Expected error for closed socket, got nil")
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	// Create temporary socket
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	// Create Unix socket listener that keeps connections open
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Failed to create socket listener: %v", err)
+	}
+	defer listener.Close()
+
+	// Accept connections and keep them open to test cancellation
+	connChan := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		connChan <- conn
+		// Keep connection open until test completes
+		<-time.After(5 * time.Second)
+		conn.Close()
+	}()
+
+	// Create session
+	session, err := NewSession(socketPath)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	defer session.Close()
+
+	// Start session in goroutine
+	done := make(chan error, 1)
+	go func() {
+		done <- session.Start()
+	}()
+
+	// Wait for connection to be established
+	select {
+	case <-connChan:
+		// Connection established, now cancel
+	case <-time.After(1 * time.Second):
+		t.Fatal("Connection not established within timeout")
+	}
+
+	// Cancel session
+	session.Close() // This should trigger context cancellation
+
+	// Wait for completion
+	select {
+	case err := <-done:
+		// Should get context.Canceled error
+		if err != context.Canceled {
+			t.Logf("Session cancelled with: %v (expected context.Canceled)", err)
+		} else {
+			t.Logf("Session properly cancelled with context.Canceled")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Session did not respond to cancellation within timeout")
+	}
+}
+
+func TestResourceCleanupVerification(t *testing.T) {
+	// Test session cleanup without actual socket connection
+	ctx, cancel := context.WithCancel(context.Background())
+	session := &Session{
+		socketConn: nil, // No actual connection for this test
+		ctx:        ctx,
+		cancel:     cancel,
+		errChan:    make(chan error, 2),
+	}
+
+	// Close session
+	err := session.Close()
+	if err != nil {
+		t.Errorf("Session.Close() returned error: %v", err)
+	}
+
+	// Verify multiple Close() calls don't panic (sync.Once protection)
+	err = session.Close()
+	if err != nil {
+		t.Errorf("Second Close() call returned error: %v", err)
+	}
+
+	// Third close should also be safe
+	err = session.Close()
+	if err != nil {
+		t.Errorf("Third Close() call returned error: %v", err)
+	}
+
+	t.Log("Resource cleanup verification completed successfully")
+}

--- a/internal/cmd/bridge.go
+++ b/internal/cmd/bridge.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/audibleblink/nx/internal/bridge"
+	"github.com/spf13/cobra"
+	"github.com/audibleblink/logerr"
+)
+
+var bridgeCmd = &cobra.Command{
+	Use:   "bridge <socket-path>",
+	Short: "Connect to Unix socket and bridge stdio",
+	Long:  `Connect to a Unix domain socket and bridge stdin/stdout through it.`,
+	Args:  cobra.ExactArgs(1),
+	Run:   runBridgeConnect,
+}
+
+func runBridgeConnect(cmd *cobra.Command, args []string) {
+	if err := runBridgeConnectWithError(args[0]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runBridgeConnectWithError(socketPath string) error {
+	session, err := bridge.NewSession(socketPath)
+	if err != nil {
+		return fmt.Errorf("failed to create session: %w", err)
+	}
+	defer session.Close()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	sessionDone := make(chan error, 1)
+	go func() {
+		sessionDone <- session.Start()
+	}()
+
+	select {
+	case err := <-sessionDone:
+		if err != nil {
+			return fmt.Errorf("session ended with error: %w", err)
+		}
+		return nil
+	case sig := <-sigChan:
+		logerr.Info("Received signal, shutting down:", sig)
+		session.Close()
+		return fmt.Errorf("interrupted by signal %v", sig)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(bridgeCmd)
+}

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -24,7 +24,11 @@ type Managers struct {
 }
 
 // NewManagers creates a new set of managers with common defaults
-func NewManagers(sessionName string, sleep time.Duration, bundledPlugins embed.FS) (*Managers, error) {
+func NewManagers(
+	sessionName string,
+	sleep time.Duration,
+	bundledPlugins embed.FS,
+) (*Managers, error) {
 	if sessionName == "" {
 		sessionName = DefaultSessionName
 	}

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -73,7 +73,11 @@ func init() {
 }
 
 // completeTargets provides completion for tmux targets
-func completeTargets(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func completeTargets(
+	cmd *cobra.Command,
+	args []string,
+	toComplete string,
+) ([]string, cobra.ShellCompDirective) {
 	managers, err := NewManagers("", 0, bundledPlugins)
 	if err != nil {
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
@@ -92,7 +96,7 @@ func completeTargets(cmd *cobra.Command, args []string, toComplete string) ([]st
 			targets = append(targets, target)
 		}
 	}
-	
+
 	// If no targets match the prefix, return all targets
 	if len(targets) == 0 && toComplete != "" {
 		// Return empty slice if no matches
@@ -104,12 +108,16 @@ func completeTargets(cmd *cobra.Command, args []string, toComplete string) ([]st
 			targets = append(targets, target)
 		}
 	}
-	
+
 	return targets, cobra.ShellCompDirectiveNoFileComp
 }
 
 // completePlugins provides completion for plugin names
-func completePlugins(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func completePlugins(
+	cmd *cobra.Command,
+	args []string,
+	toComplete string,
+) ([]string, cobra.ShellCompDirective) {
 	managers, err := NewManagers("", 0, bundledPlugins)
 	if err != nil {
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
@@ -119,7 +127,7 @@ func completePlugins(cmd *cobra.Command, args []string, toComplete string) ([]st
 	if err != nil {
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
-	
+
 	// Filter plugins based on toComplete prefix
 	var filtered []string
 	for _, plugin := range plugins {
@@ -127,11 +135,11 @@ func completePlugins(cmd *cobra.Command, args []string, toComplete string) ([]st
 			filtered = append(filtered, plugin)
 		}
 	}
-	
+
 	// If no plugins match the prefix, return all plugins
 	if len(filtered) == 0 {
 		filtered = plugins
 	}
-	
+
 	return filtered, cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -44,7 +44,7 @@ func init() {
 	execCmd.Flags().String("on", "", "Target pane using tmux notation (session:window.pane)")
 	execCmd.Flags().Bool("dry-run", false, "Preview execution without running")
 	execCmd.MarkFlagRequired("on")
-	
+
 	// Set up flag completions
 	execCmd.RegisterFlagCompletionFunc("on", completeTargets)
 	execCmd.ValidArgsFunction = completePlugins
@@ -101,39 +101,21 @@ func executeExecCommand(cfg *config.ExecCommand) {
 
 	// Execute scripts sequentially
 	logerr.Info(fmt.Sprintf("Running %d script(s) on %s...", len(scripts), cfg.On))
-	
+
 	if err := managers.Plugin.ExecuteMultipleOnPane(scripts, target, false); err != nil {
 		logerr.Fatal("Failed to execute scripts:", err)
 	}
-	
+
 	logerr.Info("All scripts completed successfully")
-}
-
-// showDryRun displays what would be executed in dry-run mode
-func showDryRun(script, target string, pluginManager *plugins.Manager) {
-	logerr.Info(fmt.Sprintf("Would run '%s' on %s:", script, target))
-
-	pluginPath := filepath.Join(pluginManager.GetPluginDir(), script+".sh")
-	content, err := os.ReadFile(pluginPath)
-	if err != nil {
-		logerr.Fatal("Failed to read plugin file:", err)
-	}
-
-	for _, line := range strings.Split(string(content), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" && !strings.HasPrefix(line, "#") {
-			logerr.Info("  " + line)
-		}
-	}
 }
 
 // showDryRunMultiple displays what would be executed for multiple scripts in dry-run mode
 func showDryRunMultiple(scripts []string, target string, pluginManager *plugins.Manager) {
 	logerr.Info(fmt.Sprintf("Would run %d script(s) on %s:", len(scripts), target))
-	
+
 	for i, script := range scripts {
 		logerr.Info(fmt.Sprintf("[%d/%d] Script '%s':", i+1, len(scripts), script))
-		
+
 		pluginPath := filepath.Join(pluginManager.GetPluginDir(), script+".sh")
 		content, err := os.ReadFile(pluginPath)
 		if err != nil {
@@ -141,13 +123,13 @@ func showDryRunMultiple(scripts []string, target string, pluginManager *plugins.
 			continue
 		}
 
-		for _, line := range strings.Split(string(content), "\n") {
+		for line := range strings.SplitSeq(string(content), "\n") {
 			line = strings.TrimSpace(line)
 			if line != "" && !strings.HasPrefix(line, "#") {
 				logerr.Info("    " + line)
 			}
 		}
-		
+
 		if i < len(scripts)-1 {
 			logerr.Info("") // Add spacing between scripts
 		}

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -48,11 +48,14 @@ func init() {
 	serveCmd.Flags().Duration("sleep", DefaultSleep, "adjust if --auto is failing")
 	serveCmd.Flags().BoolP("verbose", "v", false, "Debug logging")
 	serveCmd.Flags().StringP("ssh-pass", "s", "", "SSH password (empty = no auth)")
-	
+
 	// Set up flag completions
-	serveCmd.RegisterFlagCompletionFunc("serve-dir", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return nil, cobra.ShellCompDirectiveFilterDirs
-	})
+	serveCmd.RegisterFlagCompletionFunc(
+		"serve-dir",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveFilterDirs
+		},
+	)
 	serveCmd.RegisterFlagCompletionFunc("exec", completePlugins)
 	serveCmd.RegisterFlagCompletionFunc("target", completeTargets)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,16 +11,16 @@ import (
 // Config holds all application configuration
 
 type Config struct {
-	Auto             bool          `long:"auto"              description:"Attempt to auto-upgrade to a tty (uses --exec auto)"`
-	Exec             string        `long:"exec"              description:"Execute plugin scripts on connection (comma-separated)"`
-	InstallPlugins   bool          `long:"install-plugins"   description:"Install bundled plugins to config directory"`
-	Iface            string        `long:"host"              description:"Interface address on which to bind"                  short:"i" default:"0.0.0.0" required:"true"`
-	Port             string        `long:"port"              description:"Port on which to bind"                               short:"p" default:"8443"    required:"true"`
-	ServeDir         string        `long:"serve-dir"         description:"Directory to serve files from over HTTP"             short:"d"`
-	Target           string        `long:"target"            description:"Tmux session name"                                   short:"t" default:"nx"`
-	Sleep            time.Duration `long:"sleep"             description:"adjust if --auto is failing"                                   default:"500ms"`
-	Verbose          bool          `long:"verbose"           description:"Debug logging"                                       short:"v"`
-	SSHPass          string        `long:"ssh-pass"          description:"SSH password (empty = no auth)"                      short:"s"`
+	Auto           bool          `long:"auto"            description:"Attempt to auto-upgrade to a tty (uses --exec auto)"`
+	Exec           string        `long:"exec"            description:"Execute plugin scripts on connection (comma-separated)"`
+	InstallPlugins bool          `long:"install-plugins" description:"Install bundled plugins to config directory"`
+	Iface          string        `long:"host"            description:"Interface address on which to bind"                     short:"i" default:"0.0.0.0" required:"true"`
+	Port           string        `long:"port"            description:"Port on which to bind"                                  short:"p" default:"8443"    required:"true"`
+	ServeDir       string        `long:"serve-dir"       description:"Directory to serve files from over HTTP"                short:"d"`
+	Target         string        `long:"target"          description:"Tmux session name"                                      short:"t" default:"nx"`
+	Sleep          time.Duration `long:"sleep"           description:"adjust if --auto is failing"                                      default:"500ms"`
+	Verbose        bool          `long:"verbose"         description:"Debug logging"                                          short:"v"`
+	SSHPass        string        `long:"ssh-pass"        description:"SSH password (empty = no auth)"                         short:"s"`
 }
 
 // Validate checks if the configuration is valid
@@ -89,21 +89,21 @@ func (c *Config) GetExecScripts() []string {
 	if c.Exec == "" {
 		return nil
 	}
-	
+
 	// Split by comma and trim whitespace
 	scripts := make([]string, 0)
-	for _, script := range strings.Split(c.Exec, ",") {
+	for script := range strings.SplitSeq(c.Exec, ",") {
 		script = strings.TrimSpace(script)
 		if script != "" {
 			scripts = append(scripts, script)
 		}
 	}
-	
+
 	// Return nil if no valid scripts found
 	if len(scripts) == 0 {
 		return nil
 	}
-	
+
 	return scripts
 }
 
@@ -112,8 +112,6 @@ func (c *Config) HasExecScripts() bool {
 	return len(c.GetExecScripts()) > 0
 }
 
-
-
 // ServerCommand represents the configuration for the server subcommand (default behavior)
 
 // ExecCommand represents the configuration for the exec subcommand
@@ -121,8 +119,8 @@ type ExecCommand struct {
 	Args struct {
 		Scripts string `positional-arg-name:"scripts" description:"Name(s) of plugin script(s) to execute (comma-separated)"`
 	} `positional-args:"yes" required:"yes"`
-	On              string        `                      required:"true" long:"on"              description:"Target pane using tmux notation (session:window.pane)"`
-	DryRun          bool          `                                      long:"dry-run"         description:"Preview execution without running"`
+	On     string `                      required:"true" long:"on"      description:"Target pane using tmux notation (session:window.pane)"`
+	DryRun bool   `                                      long:"dry-run" description:"Preview execution without running"`
 }
 
 // Commands represents the available subcommands
@@ -137,21 +135,21 @@ func (e *ExecCommand) GetScripts() []string {
 	if e.Args.Scripts == "" {
 		return nil
 	}
-	
+
 	// Split by comma and trim whitespace
 	scripts := make([]string, 0)
-	for _, script := range strings.Split(e.Args.Scripts, ",") {
+	for script := range strings.SplitSeq(e.Args.Scripts, ",") {
 		script = strings.TrimSpace(script)
 		if script != "" {
 			scripts = append(scripts, script)
 		}
 	}
-	
+
 	// Return nil if no valid scripts found
 	if len(scripts) == 0 {
 		return nil
 	}
-	
+
 	return scripts
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -274,7 +274,7 @@ func TestConfigIsAutoUpgradeEnabled(t *testing.T) {
 func TestConfigDefaults(t *testing.T) {
 	// This test documents the expected default values from struct tags
 	// Note: go-flags would normally set these, but we test the expected values
-	expectedDefaults := map[string]interface{}{
+	expectedDefaults := map[string]any{
 		"Iface":  "0.0.0.0",
 		"Port":   "8443",
 		"Target": "nx",
@@ -438,8 +438,6 @@ func TestConfigHasExecScripts(t *testing.T) {
 	}
 }
 
-
-
 // TestExecCommandGetScripts tests the GetScripts method for ExecCommand
 func TestExecCommandGetScripts(t *testing.T) {
 	tests := []struct {
@@ -494,7 +492,7 @@ func TestConfigBackwardCompatibility(t *testing.T) {
 	t.Run("single script behaves like before", func(t *testing.T) {
 		config := Config{Exec: "auto"}
 		scripts := config.GetExecScripts()
-		
+
 		// Should return a slice with one element
 		require.Len(t, scripts, 1)
 		assert.Equal(t, "auto", scripts[0])
@@ -504,7 +502,7 @@ func TestConfigBackwardCompatibility(t *testing.T) {
 	t.Run("empty exec behaves like before", func(t *testing.T) {
 		config := Config{Exec: ""}
 		scripts := config.GetExecScripts()
-		
+
 		// Should return nil (no scripts)
 		assert.Nil(t, scripts)
 		assert.False(t, config.HasExecScripts())
@@ -514,7 +512,7 @@ func TestConfigBackwardCompatibility(t *testing.T) {
 		execCmd := ExecCommand{}
 		execCmd.Args.Scripts = "cleanup"
 		scripts := execCmd.GetScripts()
-		
+
 		// Should return a slice with one element
 		require.Len(t, scripts, 1)
 		assert.Equal(t, "cleanup", scripts[0])

--- a/internal/protocols/shell.go
+++ b/internal/protocols/shell.go
@@ -120,16 +120,16 @@ func (h *ShellHandler) createUnixSocket() (string, net.Listener, error) {
 	return socketFile, unixListener, nil
 }
 
-// createTmuxWindow creates a tmux window and executes the socat command
+// createTmuxWindow creates a tmux window and executes the bridge command
 func (h *ShellHandler) createTmuxWindow(socketFile string, conn net.Conn) (*gomux.Window, error) {
 	window, err := h.tmuxManager.CreateWindow(socketFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tmux window: %w", err)
 	}
 
-	socatCmd := fmt.Sprintf(" socat -d -d stdio unix-connect:'%s'", socketFile)
-	if err := h.tmuxManager.ExecuteInWindow(window, socatCmd); err != nil {
-		return nil, fmt.Errorf("failed to execute socat command: %w", err)
+	ptyCmd := fmt.Sprintf(" nx bridge %q", socketFile)
+	if err := h.tmuxManager.ExecuteInWindow(window, ptyCmd); err != nil {
+		return nil, fmt.Errorf("failed to execute bridge command: %w", err)
 	}
 
 	tmuxLoc := fmt.Sprintf("%s:%d.0", h.tmuxManager.GetSessionName(), window.Number)

--- a/internal/protocols/shell_test.go
+++ b/internal/protocols/shell_test.go
@@ -8,13 +8,3 @@ func TestNewShellHandler(t *testing.T) {
 	// Skip this test since it requires actual tmux and plugin manager
 	t.Skip("Skipping NewShellHandler test - requires complex setup")
 }
-
-
-
-
-
-
-
-
-
-

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -97,7 +97,7 @@ func (m *Manager) ExecuteInWindow(window *gomux.Window, command string) error {
 	// Use direct tmux send-keys instead of gomux Exec to avoid quote escaping
 	// Get the pane target from the window
 	targetStr := fmt.Sprintf("%s:%d.0", m.session.Name, window.Number)
-	
+
 	// Use tmux send-keys directly, same as ExecuteOnPane
 	cmd := exec.Command("tmux", "send-keys", "-t", targetStr, command, "C-m")
 	err := cmd.Run()
@@ -201,7 +201,7 @@ func (m *Manager) ExecuteOnPane(target *PaneTarget, command string) error {
 	// We need to be careful with quote handling - pass the command as a single argument
 	// to avoid Go's exec package from escaping quotes
 	cmd := exec.Command("tmux", "send-keys", "-t", targetStr, command, "C-m")
-	
+
 	// Set the command to not escape shell metacharacters
 	// by ensuring the command string is passed exactly as-is
 	err := cmd.Run()

--- a/pkg/socket/socket.go
+++ b/pkg/socket/socket.go
@@ -21,7 +21,7 @@ type Manager struct {
 func NewManager() *Manager {
 	socketDir := filepath.Join(xdg.RuntimeDir, "nx")
 	// Ensure socket directory exists
-	os.MkdirAll(socketDir, 0755)
+	os.MkdirAll(socketDir, 0o755)
 
 	return &Manager{
 		socketDir: socketDir,
@@ -53,7 +53,11 @@ func (m *Manager) CreateUnixListener(socketPath string) (net.Listener, error) {
 }
 
 // BridgeConnections bridges a TCP connection to a Unix domain socket
-func (m *Manager) BridgeConnections(ctx context.Context, tcpConn net.Conn, unixListener net.Listener) error {
+func (m *Manager) BridgeConnections(
+	ctx context.Context,
+	tcpConn net.Conn,
+	unixListener net.Listener,
+) error {
 	log := logerr.Add("BridgeConnections")
 	defer unixListener.Close()
 

--- a/pkg/socket/socket_test.go
+++ b/pkg/socket/socket_test.go
@@ -59,7 +59,7 @@ func TestManagerGenerateTempFilename(t *testing.T) {
 
 	t.Run("multiple calls generate different names", func(t *testing.T) {
 		filenames := make(map[string]bool)
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			filename, err := manager.GenerateTempFilename()
 			require.NoError(t, err)
 			assert.False(t, filenames[filename], "filename %s was generated twice", filename)
@@ -354,7 +354,7 @@ func TestConcurrentSocketOperations(t *testing.T) {
 	results := make(chan error, numOperations)
 
 	// Run multiple socket operations concurrently
-	for i := 0; i < numOperations; i++ {
+	for range numOperations {
 		go func() {
 			socketPath, err := manager.GenerateTempFilename()
 			if err != nil {
@@ -373,7 +373,7 @@ func TestConcurrentSocketOperations(t *testing.T) {
 	}
 
 	// Wait for all operations to complete
-	for i := 0; i < numOperations; i++ {
+	for range numOperations {
 		select {
 		case err := <-results:
 			assert.NoError(t, err)

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,6 @@ All-in-One:
 ## Prerequisites
 
 - tmux - required for session/window management
-- socat - required for TTY handling and keystroke forwarding
 
 ## Installation
 
@@ -137,4 +136,4 @@ unix domain sockets mannn
 - [x] ~~multiplexing listener~~ ✅ **DONE**: HTTP/shell protocol detection on same port
 - [x] ~~super simple chisel-light functionality~~ ✅ **DONE**: SSH tunneling with local/remote port forwarding
 - [x] facilitate installing plugins dir to xdg
-- [ ] handle stdio with the socket directly with `nx`, eliminating the need for `socat`
+- [x] handle stdio with the socket directly with `nx`, eliminating the need for `socat`


### PR DESCRIPTION
  - Add internal/bridge/manager.go implementing stdio bridging to Unix sockets, removing socat dependency
  - Introduce `bridge` cobra command for socket bridging, used in tmux integration
  - Update shell protocol to use `nx bridge` instead of socat for tmux window execution
